### PR TITLE
[MO-467] Minimum size of avatar should be 125px

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thewing/components",
-  "version": "1.0.7-alpha",
+  "version": "1.0.8-alpha",
   "description": "Shared components for The Wing",
   "main": "dist/index.js",
   "publishConfig": {

--- a/src/containers/Profile/components/EditForm.js
+++ b/src/containers/Profile/components/EditForm.js
@@ -108,7 +108,7 @@ const EditForm = ({
           };
 
           return (
-            <DropZone minWidth={98} onDrop={onDrop}>
+            <DropZone minWidth={125} onDrop={onDrop}>
               <Image width={125} height={125} url={input.value} hoverText="Edit" circle />
             </DropZone>
           );


### PR DESCRIPTION
## Description
Avatar in profile container should be at least 125px wide.

## Jira Ticket
[MO-467](https://thewing.atlassian.net/browse/MO-467)

## Screenshots
![screen shot 2018-10-22 at 2 42 26 pm](https://user-images.githubusercontent.com/1829422/47311822-bcc66080-d608-11e8-90e3-64017b4cbc66.png)


## How should this be manually tested?
1. Go to "default" profile story
2. Try to upload an image that is smaller than 125px wide
3. Expect to see an error message!

## Type of change

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My changes do not generate any new warnings

~- [ ] I have written tests or updated existing tests for this change~ *update when testing harness has been added*

~- [ ] New and existing tests pass locally~ *update when testing harness has been added*


