### PR TITLE
Mo 468/validating max chars

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thewing/components",
-  "version": "1.0.8-alpha",
+  "version": "1.0.9-alpha",
   "description": "Shared components for The Wing",
   "main": "dist/index.js",
   "publishConfig": {
@@ -9,9 +9,7 @@
   "repository": "git@github.com:the-wing/components.git",
   "author": "The Wing",
   "license": "MIT",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "engines": {
     "node": ">=8.11.4"
   },
@@ -55,10 +53,7 @@
     }
   },
   "lint-staged": {
-    "*.{js,json,scss,md}": [
-      "prettier --write",
-      "git add"
-    ]
+    "*.{js,json,scss,md}": ["prettier --write", "git add"]
   },
   "devDependencies": {
     "@sambego/storybook-state": "^1.3.1",

--- a/src/ui/Counter/Counter.js
+++ b/src/ui/Counter/Counter.js
@@ -11,7 +11,7 @@ const StyledCounter = styled(LabelAsSpan)`
 `;
 
 const Counter = ({ currentLength, error, maxLength }) => (
-  <StyledCounter error={error}>
+  <StyledCounter error={error || currentLength > maxLength}>
     {currentLength || 0} / {maxLength}
   </StyledCounter>
 );

--- a/src/ui/Counter/Counter.stories.js
+++ b/src/ui/Counter/Counter.stories.js
@@ -6,4 +6,5 @@ import Counter from 'ui/Counter/Counter';
 storiesOf('Counter', module)
   .addDecorator((storyFn, context) => withConsole()(storyFn)(context))
   .add('default', () => <Counter currentLength={10} maxLength={100} />)
-  .add('error', () => <Counter currentLength={10} maxLength={100} error />);
+  .add('error', () => <Counter currentLength={10} maxLength={100} error />)
+  .add('currentLength > maxLength', () => <Counter currentLength={200} maxLength={100} />);

--- a/src/ui/Forms/Select.js
+++ b/src/ui/Forms/Select.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, Component } from 'react';
 import PropTypes from 'prop-types';
 import { default as ReactSelect, components } from 'react-select';
 import Async from 'react-select/lib/Async';
@@ -16,6 +16,7 @@ import ErrorMessage from './ErrorMessage';
 
 const StyledAddLabel = styled(Box)`
   justify-content: space-between;
+  opacity: ${props => (props.disabled ? '0.5' : '1')};
 `;
 
 // prettier-ignore
@@ -93,19 +94,23 @@ const SearchableSingleValue = ({ children, ...props }) => {
   );
 };
 
-const AddLabel = ({ currentLength, error, inputValue, maxLength }) => (
-  <StyledAddLabel display="flex">
-    <Box>
-      <Icon name="add" size={10} color="terracota" />
-      <Text color="terracota" size={13 / 16} style={{ marginLeft: '0.625rem' }}>
-        Add {inputValue}
-      </Text>
-    </Box>
-    <Box>
-      {maxLength && <Counter currentLength={currentLength} error={error} maxLength={maxLength} />}
-    </Box>
-  </StyledAddLabel>
-);
+const AddLabel = ({ currentLength, error, inputValue, maxLength }) => {
+  const disabled = currentLength > maxLength || error;
+
+  return (
+    <StyledAddLabel display="flex" disabled={disabled}>
+      <Box>
+        <Icon name="add" size={10} color="terracota" />
+        <Text color="terracota" size={13 / 16} style={{ marginLeft: '0.625rem' }}>
+          Add {inputValue}
+        </Text>
+      </Box>
+      <Box>
+        {maxLength && <Counter currentLength={currentLength} error={error} maxLength={maxLength} />}
+      </Box>
+    </StyledAddLabel>
+  );
+};
 
 const customStyles = (isSearchable = false, error = false) => ({
   control: (base, state) => ({
@@ -160,10 +165,10 @@ const customStyles = (isSearchable = false, error = false) => ({
     color: theme.colors.solitude.main,
     backgroundColor: state.isFocused ? '#faf3f1' : null,
     '&:active': {
-      backgroundColor: '#eef7f1',
+      backgroundColor: state.isDisabled ? 'white' : '#eef7f1',
     },
     '&:hover': {
-      cursor: 'pointer',
+      cursor: state.isDisabled ? 'not-allowed' : 'pointer',
     },
   }),
   placeholder: (base, state) => ({
@@ -217,12 +222,20 @@ const Select = ({
               maxLength={maxLength}
             />
           )}
-          value={inputProps.value}
+          isOptionDisabled={option => {
+            if (
+              (option.__isNew__ && option.value.length > maxLength) ||
+              (error && error.length > 0)
+            ) {
+              return true;
+            }
+
+            return false;
+          }}
           options={options}
           placeholder={placeholder}
           // isSearchable = true
           styles={customStyles(true, error && error.length > 0)}
-          onChange={inputProps.onChange}
           defaultOptions={options}
           loadOptions={loadOptions}
           maxLength={maxLength}
@@ -244,8 +257,6 @@ const Select = ({
           ...searchableComponents,
         }}
         isSearchable={isSearchable}
-        value={inputProps.value}
-        onChange={inputProps.onChange}
         options={options}
         maxLength={maxLength}
         placeholder={placeholder}

--- a/src/ui/Forms/TextArea.js
+++ b/src/ui/Forms/TextArea.js
@@ -31,7 +31,7 @@ const StyledTextArea = styled.textarea`
 
 const TextArea = ({ currentLength, error, maxLength, ...textAreaProps }) => (
   <Fragment>
-    <StyledTextArea maxLength={maxLength} rows="5" error={error.length > 0} {...textAreaProps} />
+    <StyledTextArea rows="5" error={error.length > 0} {...textAreaProps} />
     {!maxLength && error.length > 0 && <ErrorMessage text={error} />}
     {maxLength && (
       <Box margin={{ vertical: 6.5 / 16 }}>


### PR DESCRIPTION
## Description
- Removed `maxLength` limiting amount of text able to be entered in `TextArea` (so that people can copy and paste and compose in Bio, but will still get error message if too long of text.
- Disabled adding of values >30 chars in Company, Asks, Offers, and Interests

## Jira Ticket
[MO-468](https://thewing.atlassian.net/browse/MO-468)

## How should this be manually tested?
1. Try to add an Interest greater than 30 chars - "Add label" should be disabled. You should not be able to add this.
2. Try to add an Offer greater than 30 chars - "Add label" should be disabled. You should not be able to add this.
3. Try to add an Ask greater than 30 chars - "Add label" should be disabled. You should not be able to add this.
4. Try to add a Company greater than 30 chars - "Add label" should be disabled. You should not be able to add this.
5. Try to add text greater than 200 chars in Bio -- counter should turn red, and on click outside of field, error message should appear. "Save" is not possible.

## Type of change

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My changes do not generate any new warnings

~- [ ] I have written tests or updated existing tests for this change~ *update when testing harness has been added*

~- [ ] New and existing tests pass locally~ *update when testing harness has been added*


