### PR TITLE
[MO-488] Only disable creatable option if there is a maxLength

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thewing/components",
-  "version": "1.1.0-alpha",
+  "version": "1.1.1-alpha",
   "description": "Shared components for The Wing",
   "main": "dist/index.js",
   "publishConfig": {

--- a/src/containers/Profile/components/EditForm.js
+++ b/src/containers/Profile/components/EditForm.js
@@ -212,6 +212,7 @@ const EditForm = ({
                       placeholder="Position (required)"
                       error={meta.touched && meta.error ? meta.error : ''}
                       {...input}
+                      maxLength={30}
                       canCreateOptions
                     />
                   </FormField>

--- a/src/ui/Forms/Select.js
+++ b/src/ui/Forms/Select.js
@@ -223,10 +223,7 @@ const Select = ({
             />
           )}
           isOptionDisabled={option => {
-            if (
-              (option.__isNew__ && option.value.length > maxLength) ||
-              (error && error.length > 0)
-            ) {
+            if (option.__isNew__ && maxLength && option.value.length > maxLength) {
               return true;
             }
 


### PR DESCRIPTION
## Description
We were disabling options in the occupation's position select (because we didn't set a maxLength)

## Jira Ticket
[MO-488](https://thewing.atlassian.net/browse/MO-488)

## How should this be manually tested?
1. Add occupation position that isn't in the dropdown and does not exceed maxLength of 30
2. You can click other options and add!
3. Try to type a position that exceeds length of 30 chars
4. Only the "created" option is disabled. Should be able to add others from dropdown.

## Type of change

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ ] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings

~- [ ] I have written tests or updated existing tests for this change~ *update when testing harness has been added*

~- [ ] New and existing tests pass locally~ *update when testing harness has been added*


