### PR TITLE
[MO-238] Fix positioning of absolute elements in carousel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thewing/components",
-  "version": "1.1.7-alpha",
+  "version": "1.1.8-alpha",
   "description": "Shared components for The Wing",
   "main": "dist/index.js",
   "publishConfig": {

--- a/src/ui/Carousel/Carousel.js
+++ b/src/ui/Carousel/Carousel.js
@@ -11,6 +11,7 @@ import 'slick-carousel/slick/slick-theme.css';
 const SlickOverrides = createGlobalStyle`
   .slick-slider {
     background: ${props => props.theme.colors.linen.main};
+    margin-bottom: ${rem('60px')};
 
     &::after {
       content: '';
@@ -49,7 +50,7 @@ const StyledPrevArrow = styled.div`
   left: 0;
   margin-left: ${rem('30px')};
   pointer-events: all;
-  z-index: 0;
+  z-index: 1;
 
   &:hover {
     cursor: pointer;

--- a/src/ui/Carousel/Carousel.stories.js
+++ b/src/ui/Carousel/Carousel.stories.js
@@ -4,6 +4,7 @@ import { withConsole } from '@storybook/addon-console';
 import styled from 'styled-components';
 import { Media } from 'react-breakpoints';
 import Carousel from 'ui/Carousel/Carousel';
+import Card from 'ui/Card/Card';
 
 const Page = styled.div`
   background: ${props => props.theme.colors.linen.main};
@@ -54,6 +55,23 @@ storiesOf('Carousel', module)
             <Carousel>
               <Slide>Slide 1 </Slide>
             </Carousel>
+          </Container>
+        )}
+      </Media>
+    </Page>
+  ))
+  .add('with cards', () => (
+    <Page>
+      <Media>
+        {({ currentBreakpoint }) => (
+          <Container currentBreakpoint={currentBreakpoint}>
+            <Carousel>
+              <Card scalloped>Card 1</Card>
+              <Card scalloped>Card 2</Card>
+              <Card scalloped>Card 3</Card>
+              <Card scalloped>Card 4</Card>
+            </Carousel>
+            <div>Some other thing</div>
           </Container>
         )}
       </Media>


### PR DESCRIPTION
## Description
Due to absolute positioning of the carousel's arrows, content that followed it was overlapping the arrows/dots. This fixes that!

## Jira Ticket
[MO-238](https://thewing.atlassian.net/browse/MO-238)

## How should this be manually tested?
1. Go to Carousel story "with cards"
2. Note that the content following the carousel does not overlap the dots/arrows.

## Type of change

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ ] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings

~- [ ] I have written tests or updated existing tests for this change~ *update when testing harness has been added*

~- [ ] New and existing tests pass locally~ *update when testing harness has been added*


