### PR TITLE
[MO-238] Add ability to tweak responsive display of Carousel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thewing/components",
-  "version": "1.1.10-alpha",
+  "version": "1.1.11-alpha",
   "description": "Shared components for The Wing",
   "main": "dist/index.js",
   "publishConfig": {

--- a/src/ui/Carousel/Carousel.js
+++ b/src/ui/Carousel/Carousel.js
@@ -124,12 +124,22 @@ const NextArrow = ({ onClick }) => <StyledNextArrow onClick={onClick} />;
 
 const PrevArrow = ({ onClick }) => <StyledPrevArrow onClick={onClick} />;
 
-const Carousel = ({ arrows, children, dots, infinite, speed, slidesToShow, slidesToScroll }) => {
+const Carousel = ({
+  arrows,
+  centerPadding,
+  children,
+  dots,
+  infinite,
+  responsiveSettings,
+  speed,
+  slidesToShow,
+  slidesToScroll,
+}) => {
   const settings = {
     appendDots,
     arrows,
     centerMode: true,
-    centerPadding: '20px',
+    centerPadding,
     className: 'center',
     dots,
     dotsClass: '',
@@ -154,6 +164,7 @@ const Carousel = ({ arrows, children, dots, infinite, speed, slidesToShow, slide
                 breakpoint: breakpoints.tablet + 1,
                 settings: {
                   arrows: false,
+                  ...responsiveSettings.tablet,
                 },
               },
               {
@@ -161,6 +172,7 @@ const Carousel = ({ arrows, children, dots, infinite, speed, slidesToShow, slide
                 settings: {
                   arrows: false,
                   slidesToShow: 1,
+                  ...responsiveSettings.mobile,
                 },
               },
             ]}
@@ -177,9 +189,14 @@ const Carousel = ({ arrows, children, dots, infinite, speed, slidesToShow, slide
 
 Carousel.propTypes = {
   arrows: PropTypes.bool,
+  centerPadding: PropTypes.string,
   children: PropTypes.node.isRequired,
   dots: PropTypes.bool,
   infinite: PropTypes.bool,
+  responsiveSettings: PropTypes.shape({
+    mobile: PropTypes.shape({}),
+    tablet: PropTypes.shape({}),
+  }),
   speed: PropTypes.number,
   slidesToShow: PropTypes.number,
   slidesToScroll: PropTypes.number,
@@ -187,8 +204,13 @@ Carousel.propTypes = {
 
 Carousel.defaultProps = {
   arrows: true,
+  centerPadding: '20px',
   dots: true,
   infinite: true,
+  responsiveSettings: {
+    mobile: {},
+    tablet: {},
+  },
   speed: 500,
   slidesToShow: 1,
   slidesToScroll: 1,

--- a/src/ui/Carousel/Carousel.stories.js
+++ b/src/ui/Carousel/Carousel.stories.js
@@ -47,6 +47,43 @@ storiesOf('Carousel', module)
       </Media>
     </Page>
   ))
+  .add('with centerPadding', () => (
+    <Page>
+      <Media>
+        {({ currentBreakpoint }) => (
+          <Container currentBreakpoint={currentBreakpoint}>
+            <Carousel centerPadding="100px">
+              <Slide>Slide 1 </Slide>
+              <Slide>Slide 2 </Slide>
+              <Slide>Slide 3</Slide>
+              <Slide>Slide 4</Slide>
+            </Carousel>
+          </Container>
+        )}
+      </Media>
+    </Page>
+  ))
+  .add('with responsiveSettings', () => (
+    <Page>
+      <Media>
+        {({ currentBreakpoint }) => (
+          <Container currentBreakpoint={currentBreakpoint}>
+            <Carousel
+              responsiveSettings={{
+                tablet: { centerPadding: '200px' },
+                mobile: { centerPadding: '20px' },
+              }}
+            >
+              <Slide>Slide 1 </Slide>
+              <Slide>Slide 2 </Slide>
+              <Slide>Slide 3</Slide>
+              <Slide>Slide 4</Slide>
+            </Carousel>
+          </Container>
+        )}
+      </Media>
+    </Page>
+  ))
   .add('one slide', () => (
     <Page>
       <Media>


### PR DESCRIPTION
## Description
I need to be able to change the appearance of the Carousel on different screen sizes! :) Just making it more customizable.

## Jira Ticket
Part of [MO-238](https://thewing.atlassian.net/browse/MO-238)

## How should this be manually tested?
1. Go to Carousel Story
2. See that on different screen sizes, the "center padding" (aka what affects the size of the slides) is different on each size.

## Type of change

_Please delete options that are not relevant._

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ ] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings

~- [ ] I have written tests or updated existing tests for this change~ *update when testing harness has been added*

~- [ ] New and existing tests pass locally~ *update when testing harness has been added*


