### PR TITLE
[MO-238] Add ability to tweak all of responsive display of Carousel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thewing/components",
-  "version": "1.1.11-alpha",
+  "version": "1.1.12-alpha",
   "description": "Shared components for The Wing",
   "main": "dist/index.js",
   "publishConfig": {

--- a/src/ui/Carousel/Carousel.js
+++ b/src/ui/Carousel/Carousel.js
@@ -161,6 +161,18 @@ const Carousel = ({
             {...settings}
             responsive={[
               {
+                breakpoint: breakpoints.desktopLarge + 1,
+                settings: {
+                  ...responsiveSettings.desktopLarge,
+                },
+              },
+              {
+                breakpoint: breakpoints.desktop + 1,
+                settings: {
+                  ...responsiveSettings.desktop,
+                },
+              },
+              {
                 breakpoint: breakpoints.tablet + 1,
                 settings: {
                   arrows: false,
@@ -194,6 +206,8 @@ Carousel.propTypes = {
   dots: PropTypes.bool,
   infinite: PropTypes.bool,
   responsiveSettings: PropTypes.shape({
+    desktopLarge: PropTypes.shape({}),
+    desktop: PropTypes.shape({}),
     mobile: PropTypes.shape({}),
     tablet: PropTypes.shape({}),
   }),
@@ -208,6 +222,8 @@ Carousel.defaultProps = {
   dots: true,
   infinite: true,
   responsiveSettings: {
+    desktopLarge: {},
+    desktop: {},
     mobile: {},
     tablet: {},
   },

--- a/src/ui/Carousel/Carousel.stories.js
+++ b/src/ui/Carousel/Carousel.stories.js
@@ -70,6 +70,8 @@ storiesOf('Carousel', module)
           <Container currentBreakpoint={currentBreakpoint}>
             <Carousel
               responsiveSettings={{
+                desktopLarge: { centerPadding: '20px' },
+                desktop: { centerPadding: '25px' },
                 tablet: { centerPadding: '200px' },
                 mobile: { centerPadding: '20px' },
               }}


### PR DESCRIPTION
## Description
Previously, had only been passing in responsive settings for 2 breakpoints. Why not all?

## Jira Ticket
Part of [MO-238](https://thewing.atlassian.net/browse/MO-238)


## How should this be manually tested?
1. Go to Carousel responsiveSettings story
2. See that "centerPadding" is different at all screen sizes now

## Type of change

_Please delete options that are not relevant._

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] I have made corresponding changes to the documentation
- [ ] My changes do not generate any new warnings

~- [ ] I have written tests or updated existing tests for this change~ *update when testing harness has been added*

~- [ ] New and existing tests pass locally~ *update when testing harness has been added*


