### PR TITLE
Add slick-carousel theme to global styles in carousel component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thewing/components",
-  "version": "1.1.14-alpha",
+  "version": "1.1.15-alpha",
   "description": "Shared components for The Wing",
   "main": "dist/index.js",
   "publishConfig": {

--- a/src/ui/Carousel/Carousel.js
+++ b/src/ui/Carousel/Carousel.js
@@ -5,10 +5,12 @@ import styled, { createGlobalStyle } from 'styled-components';
 import { rem, rgba } from 'polished';
 import { Media } from 'react-breakpoints';
 import arrow from 'assets/img/arrow.svg';
-import 'slick-carousel/slick/slick.css';
-import 'slick-carousel/slick/slick-theme.css';
+import slick from 'slick-carousel/slick/slick.css';
+import slickTheme from 'slick-carousel/slick/slick-theme.css';
 
 const SlickOverrides = createGlobalStyle`
+  ${slick}
+  ${slickTheme}
   .slick-slider {
     background: ${props => props.theme.colors.linen.main};
     margin-bottom: ${rem('60px')};


### PR DESCRIPTION
## Description
Slick/Slick theme were not being exported with styles.

## Type of change

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ ] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings

~- [ ] I have written tests or updated existing tests for this change~ *update when testing harness has been added*

~- [ ] New and existing tests pass locally~ *update when testing harness has been added*


