### PR TITLE
[MO-238] Refactor styles for Carousel without using global styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thewing/components",
-  "version": "1.1.16-alpha",
+  "version": "1.1.17-alpha",
   "description": "Shared components for The Wing",
   "main": "dist/index.js",
   "publishConfig": {

--- a/src/ui/Card/Card.js
+++ b/src/ui/Card/Card.js
@@ -16,9 +16,8 @@ const TriangleContainer = styled.div`
 
 const RightTriangleContainer = styled(TriangleContainer)`
   left: auto;
-  top: ${rem('-6px')};
-  right: 0;
-  transform: rotate(90deg);
+  right: ${rem('-3px')};
+  transform: scaleX(-1);
 `;
 
 const Triangle = () => (

--- a/src/ui/Carousel/Carousel.js
+++ b/src/ui/Carousel/Carousel.js
@@ -11,6 +11,8 @@ import slickTheme from 'slick-carousel/slick/slick-theme.css';
 const Container = styled.div`
   position: relative;
   margin-bottom: ${rem('60px')};
+  width: 100%;
+  flex: 1;
 `;
 
 const Overlay = styled.div`
@@ -159,7 +161,6 @@ const Carousel = ({
   return (
     <Container>
       <Overlay />
-      {/* <SlickOverrides numberOfSlides={children && children.length} /> */}
       <Media>
         {({ breakpoints }) => (
           <StyledReactSlick

--- a/src/ui/Carousel/Carousel.js
+++ b/src/ui/Carousel/Carousel.js
@@ -8,26 +8,28 @@ import arrow from 'assets/img/arrow.svg';
 import slick from 'slick-carousel/slick/slick.css';
 import slickTheme from 'slick-carousel/slick/slick-theme.css';
 
-const SlickOverrides = createGlobalStyle`
-  ${slick}
-  ${slickTheme}
-  .slick-slider {
-    background: ${props => props.theme.colors.linen.main};
-    margin-bottom: ${rem('60px')};
+const Container = styled.div`
+  position: relative;
+  margin-bottom: ${rem('60px')};
+`;
 
-    &::after {
-      content: '';
-      position: absolute;
-      left: 0; right: 0;
-      top: 0; bottom: 0;
-      box-shadow: ${props =>
-        `inset 40px 0px 60px -30px ${props.theme.colors.linen.main}, inset -40px 0px 60px -30px ${
-          props.theme.colors.linen.main
-        }`};
-      pointer-events: none
-      z-index: 2;
-    }
-  }
+const Overlay = styled.div`
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  margin: 0 2em;
+  box-shadow: ${props =>
+    `inset 40px 0px 60px -30px ${props.theme.colors.linen.main}, inset -40px 0px 60px -30px ${
+      props.theme.colors.linen.main
+    }`};
+  pointer-events: none;
+  z-index: 2;
+`;
+
+const StyledReactSlick = styled(ReactSlick)`
+  ${slick} ${slickTheme}
 
   .slick-slide.slick-center > div {
     margin: 0 ${rem('12px')};
@@ -155,11 +157,12 @@ const Carousel = ({
   };
 
   return (
-    <Fragment>
-      <SlickOverrides numberOfSlides={children && children.length} />
+    <Container>
+      <Overlay />
+      {/* <SlickOverrides numberOfSlides={children && children.length} /> */}
       <Media>
         {({ breakpoints }) => (
-          <ReactSlick
+          <StyledReactSlick
             {...settings}
             responsive={[
               {
@@ -194,10 +197,10 @@ const Carousel = ({
             {Children.map(children, child => (
               <div>{child}</div>
             ))}
-          </ReactSlick>
+          </StyledReactSlick>
         )}
       </Media>
-    </Fragment>
+    </Container>
   );
 };
 


### PR DESCRIPTION
## Description
Globally-injected styles were not compiling correctly on the MO side (only in prod mode) so I found a workaround that doesn't involve global styles.

## Jira Ticket
Part of [MO-238](https://thewing.atlassian.net/browse/MO-238)

## Screenshots
![screen shot 2018-11-16 at 2 10 20 pm](https://user-images.githubusercontent.com/1829422/48641931-5fc08f00-e9a9-11e8-8124-3f1f948c402e.png)



## Type of change

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ ] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings

~- [ ] I have written tests or updated existing tests for this change~ *update when testing harness has been added*

~- [ ] New and existing tests pass locally~ *update when testing harness has been added*


