### PR TITLE
[MO-491] Carousel Polish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thewing/components",
-  "version": "1.1.18-alpha",
+  "version": "1.1.19-alpha",
   "description": "Shared components for The Wing",
   "main": "dist/index.js",
   "publishConfig": {

--- a/src/ui/Carousel/Carousel.js
+++ b/src/ui/Carousel/Carousel.js
@@ -47,32 +47,46 @@ const StyledReactSlick = styled(ReactSlick)`
 `;
 
 const StyledPrevArrow = styled.div`
-  height: ${rem('21px')};
-  width: ${rem('11px')};
-  background: url(${arrow}) no-repeat;
   position: absolute;
-  bottom: -${rem('44px')};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: ${rem('44px')};
+  height: ${rem('44px')};
+  bottom: -${rem('46px')};
   left: 0;
   margin-left: ${rem('30px')};
   pointer-events: all;
   z-index: 1;
 
+  &::after {
+    content: '';
+    display: block;
+    height: ${rem('21px')};
+    width: ${rem('11px')};
+    background: url(${arrow}) no-repeat;
+  }
+
   &:hover {
     cursor: pointer;
+    opacity: 0.5;
   }
 `;
 
 const StyledNextArrow = styled(StyledPrevArrow)`
-  transform: rotate(180deg);
   left: auto;
   right: 0;
   margin-left: 0;
   margin-right: ${rem('30px')};
+
+  &::after {
+    transform: scaleX(-1);
+  }
 `;
 
 const DotContainer = styled.div`
   position: absolute;
-  bottom: -${rem('36px')};
+  bottom: -${rem('29px')};
   width: 100%;
   margin: 0 auto;
   z-index: 0;
@@ -97,6 +111,7 @@ const Dot = styled.li`
 
   &:hover {
     cursor: pointer;
+    opacity: 0.5;
   }
 
   &:not(:last-of-type) {


### PR DESCRIPTION
## Description
- Click area for controls on carousel is larger (44px x 44px)
- Hover state for both dots and arrows on carousel = 50% opacity

## Jira Ticket
[MO-491](https://thewing.atlassian.net/browse/MO-491)

## Screenshots
![screen shot 2018-11-16 at 3 42 39 pm](https://user-images.githubusercontent.com/1829422/48646258-54c02b80-e9b6-11e8-902f-d3688c5a20dd.png)
![screen shot 2018-11-16 at 3 42 33 pm](https://user-images.githubusercontent.com/1829422/48646259-54c02b80-e9b6-11e8-9f7b-8778d33221fe.png)
![screen shot 2018-11-16 at 3 42 27 pm](https://user-images.githubusercontent.com/1829422/48646260-54c02b80-e9b6-11e8-9500-8af8e67c1ca9.png)


## How should this be manually tested?
1. Go to Carousel > With Cards story
2. Hover over arrow -- confirm that the area to hover is 44x44px and that the opacity is 50%
3. Hover over a dot -- confirm that the opacity is 50%

## Type of change

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ ] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings

~- [ ] I have written tests or updated existing tests for this change~ *update when testing harness has been added*

~- [ ] New and existing tests pass locally~ *update when testing harness has been added*


