### PR TITLE
[MO-510] Fix ListItem styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thewing/components",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Shared components for The Wing",
   "main": "dist/index.js",
   "publishConfig": {

--- a/src/containers/Member/Member.js
+++ b/src/containers/Member/Member.js
@@ -267,7 +267,7 @@ const Member = ({ asksAndOfferings, imageUrl, industry, location, message, name,
           const listValuesToDisplay = list[0];
 
           return (
-            <ListItem>
+            <ListItem key={item.title}>
               {item.title && <AskAndOfferingsTitle>{item.title}:</AskAndOfferingsTitle>}
               <span>
                 <ListValues>{listValuesToDisplay.join(', ')}</ListValues>

--- a/src/ui/ListItem/ListItem.js
+++ b/src/ui/ListItem/ListItem.js
@@ -1,12 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { rem } from 'polished';
 
-import Box from 'ui/Box/Box';
 import Icon from 'ui/Icon/Icon';
-import Text from 'ui/Text/Text';
 
-export const StyledContent = styled(({ underline, ...rest }) => <Box {...rest} />)`
+const StyledListItem = styled.li`
+  display: flex;
+  flex: 1 1 auto;
+  align-items: center;
+`;
+
+const IconContainer = styled.span`
+  display: inline-block;
+  width: ${rem('40px')};
+`;
+
+export const StyledContent = styled.span`
+  display: flex;
+  flex: 1;
+  padding: ${rem('14px')} 0;
   border-bottom: ${props => (props.underline ? '1px solid rgba(164, 166, 168, 0.3)' : '')};
 
   > a,
@@ -16,21 +29,24 @@ export const StyledContent = styled(({ underline, ...rest }) => <Box {...rest} /
   }
 `;
 
+const Text = styled.span`
+  color: ${props => props.theme.colors.solitude.main};
+  font-size: ${rem('15px')};
+  letter-spacing: 0.2px;
+  line-height: ${rem('20px')};
+`;
+
 const ListItem = ({ className, children, icon, underline }) => (
-  <Box as="li" className={className}>
-    <Box as="span" vAlignContent="center">
-      {icon && (
-        <Box width={40}>
-          <Icon style={{ lineHeight: '30px' }} name={icon} size={15} color="grayChateau" />
-        </Box>
-      )}
-      <StyledContent grow padding={{ vertical: 14 / 16 }} underline={underline}>
-        <Text color="solitude" size={15 / 16} letterSpacing={0.2} lineHeight={20}>
-          {children}
-        </Text>
-      </StyledContent>
-    </Box>
-  </Box>
+  <StyledListItem className={className}>
+    {icon && (
+      <IconContainer>
+        <Icon style={{ lineHeight: '30px' }} name={icon} size={15} color="grayChateau" />
+      </IconContainer>
+    )}
+    <StyledContent underline={underline}>
+      <Text>{children}</Text>
+    </StyledContent>
+  </StyledListItem>
 );
 
 ListItem.propTypes = {


### PR DESCRIPTION
## Description
Fix styling of ListItem component so that icons are shown in the same line as the text.

## Jira Ticket
[MO-510](https://thewing.atlassian.net/browse/MO-510)

## Screenshots

BEFORE:
![image-2018-12-03-13-36-33-182](https://user-images.githubusercontent.com/1829422/49475537-7bb79380-f7e5-11e8-8e29-962d2d0bbf04.png)

AFTER: 
<img width="311" alt="screen shot 2018-12-04 at 4 56 16 pm" src="https://user-images.githubusercontent.com/1829422/49475562-8f62fa00-f7e5-11e8-90af-3cb86ac0318e.png">



## How should this be manually tested?
1. Go to Profile story
2. Check that icons are aligned with text in "additional info" section (at bottom)

## Type of change

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings

~- [ ] I have written tests or updated existing tests for this change~ *update when testing harness has been added*

~- [ ] New and existing tests pass locally~ *update when testing harness has been added*


