### PR TITLE
[MO-537] Members messages should be able have shorter text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thewing/components",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Shared components for The Wing",
   "main": "dist/index.js",
   "publishConfig": {

--- a/src/containers/Member/Member.js
+++ b/src/containers/Member/Member.js
@@ -223,6 +223,14 @@ const MatchIcon = styled.div`
   }
 `;
 
+const MessageContainer = styled.span`
+  flex: 1 1 auto;
+
+  @media ${props => props.theme.queries.tablet} {
+    min-width: ${rem('510px')};
+  }
+`;
+
 const MessageText = styled.span`
   color: ${props => props.theme.colors.blueDark.main}
   font-size: ${rem('12px')};
@@ -279,12 +287,14 @@ const Member = ({ asksAndOfferings, imageUrl, industry, location, message, name,
       </AsksAndOfferings>
     )}
     {message && (
-      <StyledMessage>
-        <MessageContent>
-          <MatchIcon />
-          <MessageText>{message}</MessageText>
-        </MessageContent>
-      </StyledMessage>
+      <MessageContainer>
+        <StyledMessage>
+          <MessageContent>
+            <MatchIcon />
+            <MessageText>{message}</MessageText>
+          </MessageContent>
+        </StyledMessage>
+      </MessageContainer>
     )}
   </Container>
 );

--- a/src/containers/Member/Member.stories.js
+++ b/src/containers/Member/Member.stories.js
@@ -58,4 +58,18 @@ storiesOf('Member', module)
         <Member {...data.ronWithAsksAndOfferingsAndMessage} />
       </Content>
     </Page>
+  ))
+  .add('with short asks/offerings', () => (
+    <Page>
+      <Content>
+        <Member {...data.garryWithAsksAndOfferingsAndMessage} />
+      </Content>
+    </Page>
+  ))
+  .add('with short message', () => (
+    <Page>
+      <Content>
+        <Member {...data.garryWithMessage} />
+      </Content>
+    </Page>
   ));

--- a/src/containers/Member/Member.storyData.js
+++ b/src/containers/Member/Member.storyData.js
@@ -12,6 +12,13 @@ const ron = {
   position: 'Director of the Pawnee City Department of Parks and Recreation',
 };
 
+const garry = {
+  industry: 'Government',
+  location: 'All Access, Soho',
+  name: 'Garry Gergich',
+  position: 'Employee',
+};
+
 const leslieWithAsksAndOfferings = {
   ...leslie,
   asksAndOfferings: [
@@ -40,6 +47,20 @@ const ronWithAsksAndOfferings = {
   ],
 };
 
+const garryWithAsksAndOfferings = {
+  ...garry,
+  asksAndOfferings: [
+    {
+      title: 'Offering',
+      values: ['Smiles'],
+    },
+    {
+      title: 'Asking',
+      values: ['You get his name right please?'],
+    },
+  ],
+};
+
 const leslieWithMessage = {
   ...leslie,
   message:
@@ -50,6 +71,11 @@ const ronWithMessage = {
   ...ron,
   message:
     'You and Leslie Knope attended the same event yesterday. You are also both interested in waffles.',
+};
+
+const garryWithMessage = {
+  ...garry,
+  message: "Isn't his name Jerry?",
 };
 
 export const data = {
@@ -66,5 +92,12 @@ export const data = {
   ronWithAsksAndOfferingsAndMessage: {
     ...ronWithAsksAndOfferings,
     ...ronWithMessage,
+  },
+  garry,
+  garryWithAsksAndOfferings,
+  garryWithMessage,
+  garryWithAsksAndOfferingsAndMessage: {
+    ...garryWithAsksAndOfferings,
+    ...garryWithMessage,
   },
 };

--- a/src/ui/List/List.stories.js
+++ b/src/ui/List/List.stories.js
@@ -85,6 +85,9 @@ storiesOf('List', module)
           <StyledListItem underline>
             <Member {...memberData.ronWithAsksAndOfferingsAndMessage} />
           </StyledListItem>
+          <StyledListItem underline>
+            <Member {...memberData.garryWithMessage} />
+          </StyledListItem>
         </List>
       </Content>
     </Page>

--- a/src/ui/Message/Message.js
+++ b/src/ui/Message/Message.js
@@ -5,6 +5,7 @@ import { rem } from 'polished';
 import pinkCurve from 'assets/img/pinkCurve.svg';
 
 const StyledMessage = styled.div`
+  display: flex;
   position: relative;
   background: ${props => props.theme.colors.potpourri.main};
   padding: ${rem('14px')} ${rem('20px')};
@@ -23,6 +24,7 @@ const StyledMessage = styled.div`
   }
 
   @media ${props => props.theme.queries.tablet} {
+    display: inline-block;
     border-radius: ${rem('40px')};
     margin-top: 0;
 
@@ -32,8 +34,14 @@ const StyledMessage = styled.div`
   }
 `;
 
+const Content = styled.span`
+  display: flex;
+`;
+
 const Message = ({ children, className }) => (
-  <StyledMessage className={className}>{children}</StyledMessage>
+  <StyledMessage className={className}>
+    <Content>{children}</Content>
+  </StyledMessage>
 );
 
 Message.propTypes = {


### PR DESCRIPTION
## Description
Previously, when you have shorter text for "Message" component, it would stay on the same row as the Member's info. Now it has a container with a min width, and Message component itself does not automatically take up 100% width unless on mobile.

## Jira Ticket
[Link Here](https://thewing.atlassian.net/)

## Screenshots
BEFORE:
<img width="884" alt="screen shot 2018-12-12 at 1 59 17 pm" src="https://user-images.githubusercontent.com/1829422/49892105-264b3a00-fe16-11e8-8aaf-140cc101586f.png">

AFTER:
<img width="812" alt="screen shot 2018-12-12 at 1 59 41 pm" src="https://user-images.githubusercontent.com/1829422/49892122-3236fc00-fe16-11e8-8020-c7dd5575c654.png">


## How should this be manually tested?
1. Go to Message component, confirm that it's not full width
2.  Go to Members > with short message or short asks/offerings and confirm that the message is always on the bottom

## Type of change

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ ] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings

~- [ ] I have written tests or updated existing tests for this change~ *update when testing harness has been added*

~- [ ] New and existing tests pass locally~ *update when testing harness has been added*


