### PR TITLE
[MO-537] Members cell tweak for very very short info

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thewing/components",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Shared components for The Wing",
   "main": "dist/index.js",
   "publishConfig": {

--- a/src/containers/Member/Member.js
+++ b/src/containers/Member/Member.js
@@ -34,6 +34,7 @@ const Info = styled.div`
 
   @media ${props => props.theme.queries.tablet} {
     max-width: ${rem('332px')};
+    min-width: ${rem('332px')};
   }
 `;
 

--- a/src/containers/Member/Member.stories.js
+++ b/src/containers/Member/Member.stories.js
@@ -72,4 +72,18 @@ storiesOf('Member', module)
         <Member {...data.garryWithMessage} />
       </Content>
     </Page>
+  ))
+  .add('with short info', () => (
+    <Page>
+      <Content>
+        <Member
+          {...data.garryWithMessage}
+          name="G"
+          location="G"
+          position="G"
+          industry="G"
+          message="G"
+        />
+      </Content>
+    </Page>
   ));


### PR DESCRIPTION
## Description
When a member had a really short name, the message was still wrapping into the first row... oops

## Jira Ticket
Part of https://thewing.atlassian.net/browse/MO-537

## Screenshots
BEFORE:

<img width="818" alt="screen shot 2018-12-12 at 2 34 34 pm" src="https://user-images.githubusercontent.com/1829422/49894143-3285c600-fe1b-11e8-8502-2732ce85777f.png">


AFTER: 
<img width="285" alt="screen shot 2018-12-12 at 2 32 29 pm" src="https://user-images.githubusercontent.com/1829422/49894158-3dd8f180-fe1b-11e8-83ca-e3f56c111c07.png">



## Type of change

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ ] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings

~- [ ] I have written tests or updated existing tests for this change~ *update when testing harness has been added*

~- [ ] New and existing tests pass locally~ *update when testing harness has been added*


