### PR TITLE
[MO-537] Remove location seperator pseudo-element on mobile if no ask…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thewing/components",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Shared components for The Wing",
   "main": "dist/index.js",
   "publishConfig": {

--- a/src/containers/Member/Member.js
+++ b/src/containers/Member/Member.js
@@ -100,7 +100,7 @@ const Location = styled.div`
 
   &::after {
     content: '';
-    display: block;
+    display: ${props => (props.hasAsksAndOfferings ? 'block' : 'none')};
     position: absolute;
     bottom: ${rem('-15px')};
     width: ${rem('93px')};
@@ -257,7 +257,7 @@ const Member = ({ asksAndOfferings, imageUrl, industry, location, message, name,
         {position && <Position>{position}</Position>}
         {industry && <Industry>{industry}</Industry>}
         {location && (
-          <Location>
+          <Location hasAsksAndOfferings={asksAndOfferings.length > 0}>
             <Icon name="homebase" size={16} color="grayChateau" />
             <LocationText>{location}</LocationText>
           </Location>


### PR DESCRIPTION
## Description
Remove location seperator pseudo-element on mobile if no asks/offerings

## Jira Ticket
https://thewing.atlassian.net/browse/MO-537

## Screenshots
Before:
<img width="372" alt="screen shot 2018-12-12 at 5 17 14 pm" src="https://user-images.githubusercontent.com/1829422/49902434-f27e0d80-fe31-11e8-8921-0be54723bcd6.png">

After:
<img width="364" alt="screen shot 2018-12-12 at 5 17 43 pm" src="https://user-images.githubusercontent.com/1829422/49902442-f578fe00-fe31-11e8-9030-c714d36f1b58.png">

## How should this be manually tested?
1. View Default Member on mobile
2. Confirm that yellow-orange-ish bottom border is not there

## Type of change

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ ] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings

~- [ ] I have written tests or updated existing tests for this change~ *update when testing harness has been added*

~- [ ] New and existing tests pass locally~ *update when testing harness has been added*


