### PR TITLE
Mo 499/carousel tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thewing/components",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Shared components for The Wing",
   "main": "dist/index.js",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     }
   },
   "lint-staged": {
-    "*.{js}": [
+    "*.js": [
       "eslint --format 'node_modules/eslint-friendly-formatter'",
       "prettier --write",
       "git add"

--- a/src/ui/Carousel/Carousel.js
+++ b/src/ui/Carousel/Carousel.js
@@ -1,4 +1,4 @@
-import React, { Children } from 'react';
+import React, { Children, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import ReactSlick from 'react-slick';
 import styled from 'styled-components';
@@ -22,11 +22,24 @@ const Overlay = styled.div`
   top: 0;
   bottom: 0;
   box-shadow: ${props =>
-    `inset 40px 0px 60px -30px ${props.theme.colors.linen.main}, inset -40px 0px 60px -30px ${
+    `inset ${props.isLastSlide ? rem('40px') : rem('-40px')} 0 ${rem('60px')} ${rem('-30px')} ${
       props.theme.colors.linen.main
     }`};
   pointer-events: none;
   z-index: 2;
+
+  &::before {
+    position: absolute;
+    content: '';
+    display: block;
+    top: 0;
+    left: ${props => (props.isLastSlide ? 'auto' : '0')};
+    right: ${props => (props.isLastSlide ? '0' : 'auto')};
+    height: 100%;
+    width: ${rem('30px')};
+    background: ${props => props.theme.colors.linen.main};
+    z-index: 3;
+  }
 `;
 
 const StyledReactSlick = styled(ReactSlick)`
@@ -144,80 +157,94 @@ const NextArrow = ({ onClick }) => <StyledNextArrow onClick={onClick} />;
 
 const PrevArrow = ({ onClick }) => <StyledPrevArrow onClick={onClick} />;
 
-const Carousel = ({
-  arrows,
-  centerPadding,
-  children,
-  dots,
-  infinite,
-  responsiveSettings,
-  speed,
-  slidesToShow,
-  slidesToScroll,
-}) => {
-  const settings = {
-    appendDots,
-    arrows,
-    centerMode: true,
-    centerPadding,
-    className: 'center',
-    dots,
-    dotsClass: '',
-    infinite,
-    initialSlide: 0,
-    nextArrow: <NextArrow />,
-    prevArrow: <PrevArrow />,
-    speed,
-    slidesToShow,
-    slidesToScroll,
+class Carousel extends PureComponent {
+  state = {
+    slideIndex: 0,
   };
 
-  return (
-    <Container>
-      <Overlay />
-      <Media>
-        {({ breakpoints }) => (
-          <StyledReactSlick
-            {...settings}
-            responsive={[
-              {
-                breakpoint: breakpoints.desktopLarge + 1,
-                settings: {
-                  ...responsiveSettings.desktopLarge,
+  beforeChange = (prevIndex, nextIndex) => {
+    this.setState(() => ({ slideIndex: nextIndex }));
+  };
+
+  render() {
+    const {
+      arrows,
+      centerMode,
+      centerPadding,
+      children,
+      dots,
+      infinite,
+      responsiveSettings,
+      speed,
+      slidesToShow,
+      slidesToScroll,
+    } = this.props;
+
+    const settings = {
+      appendDots,
+      arrows,
+      beforeChange: this.beforeChange,
+      centerMode,
+      centerPadding: centerMode ? centerPadding : null,
+      className: centerMode ? 'center' : '',
+      dots,
+      dotsClass: '',
+      infinite,
+      initialSlide: 0,
+      nextArrow: <NextArrow />,
+      prevArrow: <PrevArrow />,
+      speed,
+      slidesToShow,
+      slidesToScroll,
+    };
+
+    return (
+      <Container>
+        <Overlay isLastSlide={this.state.slideIndex + 1 === children.length} />
+        <Media>
+          {({ breakpoints }) => (
+            <StyledReactSlick
+              {...settings}
+              responsive={[
+                {
+                  breakpoint: breakpoints.desktopLarge + 1,
+                  settings: {
+                    ...responsiveSettings.desktopLarge,
+                  },
                 },
-              },
-              {
-                breakpoint: breakpoints.desktop + 1,
-                settings: {
-                  ...responsiveSettings.desktop,
+                {
+                  breakpoint: breakpoints.desktop + 1,
+                  settings: {
+                    ...responsiveSettings.desktop,
+                  },
                 },
-              },
-              {
-                breakpoint: breakpoints.tablet + 1,
-                settings: {
-                  arrows: false,
-                  ...responsiveSettings.tablet,
+                {
+                  breakpoint: breakpoints.tablet + 1,
+                  settings: {
+                    arrows: false,
+                    ...responsiveSettings.tablet,
+                  },
                 },
-              },
-              {
-                breakpoint: breakpoints.mobile + 1,
-                settings: {
-                  arrows: false,
-                  slidesToShow: 1,
-                  ...responsiveSettings.mobile,
+                {
+                  breakpoint: breakpoints.mobile + 1,
+                  settings: {
+                    arrows: false,
+                    slidesToShow: 1,
+                    ...responsiveSettings.mobile,
+                  },
                 },
-              },
-            ]}
-          >
-            {Children.map(children, child => (
-              <div>{child}</div>
-            ))}
-          </StyledReactSlick>
-        )}
-      </Media>
-    </Container>
-  );
-};
+              ]}
+            >
+              {Children.map(children, child => (
+                <div>{child}</div>
+              ))}
+            </StyledReactSlick>
+          )}
+        </Media>
+      </Container>
+    );
+  }
+}
 
 Carousel.propTypes = {
   arrows: PropTypes.bool,
@@ -238,6 +265,7 @@ Carousel.propTypes = {
 
 Carousel.defaultProps = {
   arrows: true,
+  centerMode: true,
   centerPadding: '20px',
   dots: true,
   infinite: true,

--- a/src/ui/Carousel/Carousel.stories.js
+++ b/src/ui/Carousel/Carousel.stories.js
@@ -104,10 +104,9 @@ storiesOf('Carousel', module)
           <Container
             currentBreakpoint={currentBreakpoint}
             responsiveSettings={{
-              desktopLarge: { centerPadding: '20px' },
-              desktop: { centerPadding: '25px' },
-              tablet: { centerPadding: '200px' },
-              mobile: { centerPadding: '20px' },
+              desktop: { centerPadding: '197px', arrows: false },
+              tablet: { centerPadding: '197px' },
+              mobile: { centerPadding: '10px' },
             }}
           >
             <Carousel>

--- a/src/ui/Loading/Circle.js
+++ b/src/ui/Loading/Circle.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
 import { RoundShape as ReactPlaceholderRoundShape } from 'react-placeholder/lib/placeholders';
-import theme from 'theme';
 import { rgba } from 'polished';
 import { shimmerAnimation } from './animation';
 

--- a/src/ui/Loading/TextRow.js
+++ b/src/ui/Loading/TextRow.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
 import { TextRow as ReactPlaceholderTextRow } from 'react-placeholder/lib/placeholders';
-import theme from 'theme';
 import { rgba } from 'polished';
 import { shimmerAnimation } from './animation';
 


### PR DESCRIPTION
## Description
Only show next slide to the left or right.

## Jira Ticket
https://thewing.atlassian.net/browse/MO-499

## Screenshots
<img width="432" alt="screen shot 2018-12-19 at 4 18 21 pm" src="https://user-images.githubusercontent.com/1829422/50248651-c4f11100-03a9-11e9-8fa9-6c79a681651f.png">
<img width="506" alt="screen shot 2018-12-19 at 4 18 17 pm" src="https://user-images.githubusercontent.com/1829422/50248652-c4f11100-03a9-11e9-84fa-c9d7103cdd3e.png">


## How should this be manually tested?
1. Go to carousel story for "Card"
2. Confirm that only preview of next slide shows on the right on slides 1-3
3. Confirm that only preview of previous slide shows on left on slide 4

## Type of change

_Please delete options that are not relevant._

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ ] I have made corresponding changes to the documentation
- [x] My changes do not generate any new warnings

~- [ ] I have written tests or updated existing tests for this change~ *update when testing harness has been added*

~- [ ] New and existing tests pass locally~ *update when testing harness has been added*


